### PR TITLE
Fixes issues when logging out of the service

### DIFF
--- a/app/api/api_v1/endpoints/unit.py
+++ b/app/api/api_v1/endpoints/unit.py
@@ -3,7 +3,6 @@ from sqlalchemy.orm import Session
 
 import crud
 from api import deps
-from models import User
 from schemas import Units, UnitCreate, Message, UnitDelete
 from crud import unit
 

--- a/app/api/api_v1/endpoints/user.py
+++ b/app/api/api_v1/endpoints/user.py
@@ -35,7 +35,7 @@ def register(
     if settings.USING_GATEKEEPER:
         try:
             response = requests.post(
-                url=str(settings.GATEKEEPER_BASE_URL) + "/api/register/",
+                url=str(settings.GATEKEEPER_BASE_URL) + "api/register/",
                 headers={"Content-Type": "application/json"},
                 json={"username": user_information.email,
                       "email": user_information.email, "password": user_information.password}

--- a/app/api/deps.py
+++ b/app/api/deps.py
@@ -10,6 +10,7 @@ from crud import user
 
 from core.config import settings
 from db.session import SessionLocal
+from utils import check_token_for_validity
 
 reusable_oauth2 = OAuth2PasswordBearer(tokenUrl="/api/v1/login/access-token/")
 
@@ -23,7 +24,8 @@ def get_db() -> Generator:
 
 
 def get_jwt(
-        token: str = Depends(reusable_oauth2)
+        token: str = Depends(reusable_oauth2),
+        db: Session = Depends(get_db)
 ):
     if not token:
         raise HTTPException(
@@ -31,7 +33,42 @@ def get_jwt(
             detail="Not authenticated"
         )
 
+    # If you're using the gatekeeper, check whether the token in question is real
+    if settings.USING_GATEKEEPER:
+        if not check_token_for_validity(token=token, token_type="access"):
+            raise HTTPException(
+                status_code=400,
+                detail="Error, invalid token"
+            )
+    else:
+        user_id = decode_token(access_token=token)
+        user_db = user.get(db=db, id=user_id)
+        if not user_db:
+            raise HTTPException(
+                status_code=400,
+                detail="Error, invalid token"
+            )
+
     return token
+
+def get_refresh_token(
+        refresh_token: str = None
+):
+    if not refresh_token:
+        raise HTTPException(
+            status_code=401,
+            detail="Not authenticated"
+        )
+
+    # If you're using the gatekeeper, check whether the token in question is real
+    if settings.USING_GATEKEEPER:
+        if not check_token_for_validity(token=refresh_token, token_type="refresh"):
+            raise HTTPException(
+                status_code=400,
+                detail="Error, invalid token"
+            )
+
+    return refresh_token
 
 
 # Only use when you're expecting a token that came from PDM, not GK

--- a/app/core/security.py
+++ b/app/core/security.py
@@ -20,22 +20,11 @@ def _create_jwt(
     return jw_token
 
 
-def create_access_token(
-        subject: str
+def create_token(
+        subject: str,
+        expiration_time: int
 ) -> str:
-
-    expire = datetime.now() + timedelta(minutes=settings.ACCESS_TOKEN_EXPIRATION_TIME)
-
-    jw_token = _create_jwt(expiration_time=expire, subject=subject)
-
-    return jw_token
-
-
-def create_refresh_token(
-        subject: str
-) -> str:
-
-    expire = datetime.now() + timedelta(minutes=settings.REFRESH_TOKEN_EXPIRATION_TIME)
+    expire = datetime.now() + timedelta(minutes=expiration_time)
 
     jw_token = _create_jwt(expiration_time=expire, subject=subject)
 

--- a/app/init/init_gatekeeper.py
+++ b/app/init/init_gatekeeper.py
@@ -12,7 +12,7 @@ def register_apis_to_gatekeeper():
     # Login
     try:
         at = requests.post(
-            url=str(settings.GATEKEEPER_BASE_URL) + "/api/login/",
+            url=str(settings.GATEKEEPER_BASE_URL) + "api/login/",
             headers={"Content-Type": "application/json"},
             json={
                 "username": "{}".format(settings.GATEKEEPER_USERNAME),
@@ -38,7 +38,7 @@ def register_apis_to_gatekeeper():
     for api in apis_to_register.routes:
         try:
             requests.post(
-                url=str(settings.GATEKEEPER_BASE_URL) + "/api/register_service/",
+                url=str(settings.GATEKEEPER_BASE_URL) + "api/register_service/",
                 headers={"Content-Type": "application/json", "Authorization" : "Bearer {}".format(access)},
                 json={
                     "base_url": "http://{}:{}/".format(settings.SERVICE_NAME, settings.SERVICE_PORT),
@@ -50,7 +50,7 @@ def register_apis_to_gatekeeper():
         except RequestException:
             try:
                 requests.post(
-                    url=str(settings.GATEKEEPER_BASE_URL) + "/api/logout/",
+                    url=str(settings.GATEKEEPER_BASE_URL) + "api/logout/",
                     headers={"Content-Type": "application/json"},
                     json={"refresh": refresh}
                 )
@@ -61,7 +61,7 @@ def register_apis_to_gatekeeper():
     # Logout
     try:
         requests.post(
-            url=str(settings.GATEKEEPER_BASE_URL) + "/api/logout/",
+            url=str(settings.GATEKEEPER_BASE_URL) + "api/logout/",
             headers={"Content-Type": "application/json"},
             json={"refresh": refresh}
         )

--- a/app/utils/gkutils.py
+++ b/app/utils/gkutils.py
@@ -10,7 +10,8 @@ def gatekeeper_logout(
 ):
     try:
         response = requests.post(
-            url=settings.GATEKEEPER_BASE_URL + "/api/logout/",
+            url=str(settings.GATEKEEPER_BASE_URL) + "api/logout/",
+            headers={"Content-Type": "application/json"},
             json={
                 "refresh": "{}".format(refresh_token)
             }
@@ -26,3 +27,50 @@ def gatekeeper_logout(
             status_code=400,
             detail="Error, missing refresh token"
         )
+
+    if response.status_code == 500:
+        raise HTTPException(
+            status_code=400,
+            detail="Error, gatekeeper returned a 500!"
+        )
+
+def check_token_for_validity(
+        token: str,
+        token_type: str
+):
+    try:
+        response = requests.post(
+            url=str(settings.GATEKEEPER_BASE_URL) + "api/validate_token/",
+            headers={"Content-Type": "application/json"},
+            json={
+                "token": token,
+                "token_type": token_type # Can be either access or refresh
+            }
+        )
+    except RequestException as re:
+        raise HTTPException(
+            status_code=400,
+            detail="Error, can't connect to gatekeeper instance [{}]".format(re)
+        )
+
+    if response.status_code == 400:
+
+        response_json = response.json()
+
+        if "error" in response_json:
+            error_message = response_json["error"]
+
+            if error_message == "Token is required":
+                raise HTTPException(
+                    status_code=400,
+                    detail="Error, missing token"
+                )
+        return False
+
+    if response.status_code == 500:
+        raise HTTPException(
+            status_code=400,
+            detail="Error, gatekeeper returned a 500"
+        )
+
+    return True


### PR DESCRIPTION
Found out a bug that raised a 500 from the service, when using the logout API
Mostly due to an improper call to the gatekeeper service

Added a separate utils function, that takes in a token and queries the api/validate_token/ api from the GK to check whether the received token is indeed valid

Also refactored two functions in the security.py module into one, that differentiates jwt_token exp. times by the input parameter, instead of having two separate functions with their own times

This update also makes the upcoming PR easier to implement, since it will be easier to manage API calls to the GK, when using proxy calls to other services (mainly FC for the upcoming PR)