### PR TITLE
GDD and Risk Index calculation using fellow OA services

### DIFF
--- a/app/api/api_v1/api.py
+++ b/app/api/api_v1/api.py
@@ -1,5 +1,5 @@
 from fastapi import APIRouter
-from .endpoints import login, user, data, rule, unit, operator, tool, pest_model, parcel, disease
+from .endpoints import login, user, data, rule, unit, operator, tool, pest_model, parcel, disease, model
 
 api_router = APIRouter()
 api_router.include_router(login.router, prefix="/login", tags=["login"])
@@ -12,3 +12,4 @@ api_router.include_router(tool.router, prefix="/tool", tags=["tool"])
 api_router.include_router(pest_model.router, prefix="/pest-model", tags=["pest-model"])
 api_router.include_router(parcel.router, prefix="/parcel", tags=["parcel"])
 api_router.include_router(disease.router, prefix="/disease", tags=["disease"])
+api_router.include_router(model.router, prefix="/model", tags=["model"])

--- a/app/api/api_v1/endpoints/model.py
+++ b/app/api/api_v1/endpoints/model.py
@@ -1,0 +1,66 @@
+from fastapi import APIRouter, Depends, HTTPException
+from sqlalchemy.orm import Session
+
+import crud
+from api import deps
+import datetime
+
+
+from schemas import DatasetIds, list_path_param
+from utils import fetch_parcel_by_id, fetch_parcel_lat_lon, fetch_weather_data, calculate_gdd_wd
+
+router = APIRouter()
+
+@router.get("/{model_ids}/gdd/", dependencies=[Depends(deps.is_using_gatekeeper)])
+def calculate_gdd_fc(
+        parcel_id: str,
+        from_date: datetime.date,
+        to_date: datetime.date,
+        access_token: str = Depends(deps.get_jwt),
+        model_ids: DatasetIds = Depends(list_path_param),
+        db: Session = Depends(deps.get_db)
+
+):
+    """
+    Calculates and returns GDD values (uses resources located on fc)
+    """
+
+    if from_date > to_date:
+        raise HTTPException(
+            status_code=400,
+            detail="from_date must be later than to_date, from_date: {} | to_date: {}".format(from_date, to_date)
+        )
+
+    parcel_fc = fetch_parcel_by_id(access_token=access_token, parcel_id=parcel_id)
+
+    if not parcel_fc:
+        raise HTTPException(
+            status_code=400,
+            detail="Parcel with ID:{} doesn't exist".format(parcel_id)
+        )
+
+    lat, lon = fetch_parcel_lat_lon(parcel_fc)
+
+    # Now that we have a (lat,lon) pair, we can query the weather service for weather data
+    weather_data = fetch_weather_data(
+        latitude=lat, longitude=lon, access_token=access_token, start_date=from_date, end_date=to_date, variables=["temperature_2m_max"]
+    )
+
+    # Fetch the disease models from the DB
+    disease_models_db = []
+    for disease_id in model_ids.ids:
+        disease_model_db = crud.disease.get(db=db, id=disease_id)
+        if not disease_model_db:
+            raise HTTPException(
+                status_code=400,
+                detail="Error, model with ID {} does not exist".format(disease_id)
+            )
+
+        disease_models_db.append(disease_model_db)
+
+    calculation_results = calculate_gdd_wd(
+        disease_models=disease_models_db,
+        weather_data=weather_data
+    )
+
+    return calculation_results

--- a/app/api/api_v1/endpoints/model.py
+++ b/app/api/api_v1/endpoints/model.py
@@ -1,3 +1,5 @@
+from typing import Literal
+
 from fastapi import APIRouter, Depends, HTTPException
 from sqlalchemy.orm import Session
 
@@ -7,7 +9,10 @@ import datetime
 
 
 from schemas import DatasetIds, list_path_param
-from utils import fetch_parcel_by_id, fetch_parcel_lat_lon, fetch_weather_data, calculate_gdd_wd
+from utils import fetch_parcel_by_id, fetch_parcel_lat_lon, fetch_weather_data, calculate_gdd_wd, \
+    openmeteo_friendly_variables, TimeUnit, calculate_risk_index_probability_wd
+
+from http import HTTPStatus
 
 router = APIRouter()
 
@@ -43,7 +48,12 @@ def calculate_gdd_fc(
 
     # Now that we have a (lat,lon) pair, we can query the weather service for weather data
     weather_data = fetch_weather_data(
-        latitude=lat, longitude=lon, access_token=access_token, start_date=from_date, end_date=to_date, variables=["temperature_2m_max"]
+        latitude=lat,
+        longitude=lon,
+        access_token=access_token,
+        start_date=from_date,
+        end_date=to_date,
+        variables=["temperature_2m_max"]
     )
 
     # Fetch the disease models from the DB
@@ -61,6 +71,80 @@ def calculate_gdd_fc(
     calculation_results = calculate_gdd_wd(
         disease_models=disease_models_db,
         weather_data=weather_data
+    )
+
+    return calculation_results
+
+@router.get("/{model_ids}/risk-index/", dependencies=[Depends(deps.is_using_gatekeeper)])
+def calculate_risk_index_fc(
+        parcel_id: str,
+        from_date: datetime.date,
+        to_date: datetime.date,
+        access_token: str = Depends(deps.get_jwt),
+        model_ids: DatasetIds = Depends(list_path_param),
+        db: Session = Depends(deps.get_db),
+        formatting: Literal["JSON", "JSON-LD"] = "JSON-LD"
+):
+    """
+    Calculates and returns risk index values (uses resources located on fc)
+    """
+
+    if formatting == "JSON":
+        raise HTTPException(
+            status_code=HTTPStatus.NOT_IMPLEMENTED,
+            detail="Error, the JSON format has yet to be implemented"
+        )
+
+    if from_date > to_date:
+        raise HTTPException(
+            status_code=400,
+            detail="from_date must be later than to_date, from_date: {} | to_date: {}".format(from_date, to_date)
+        )
+
+    parcel_fc = fetch_parcel_by_id(access_token=access_token, parcel_id=parcel_id)
+
+    if not parcel_fc:
+        raise HTTPException(
+            status_code=400,
+            detail="Parcel with ID:{} doesn't exist".format(parcel_id)
+        )
+
+    # Fetch the pest models from the database AND fetch a unique list of the units they require
+    variables_for_weather_data_call = []
+    pest_models_db = []
+    for pest_id in model_ids.ids:
+        pest_model_db = crud.pest_model.get(db=db, id=pest_id)
+        if not pest_model_db:
+            raise HTTPException(
+                status_code=400,
+                detail="Error, model with ID {} does not exist".format(pest_id)
+            )
+
+        pest_models_db.append(pest_model_db)
+
+        # Appends the list of units
+        list_of_values = list(set([condition.unit.name for rule in pest_model_db.rules for condition in rule.conditions]))
+
+        variables_for_weather_data_call += list_of_values
+
+    lat, lon = fetch_parcel_lat_lon(parcel_fc)
+
+    variables_for_weather_data_call_openmeteo = [openmeteo_friendly_variables[var_name] for var_name in variables_for_weather_data_call]
+
+    # Now that we have a (lat,lon) pair, we can query the weather service for weather data
+    weather_data = fetch_weather_data(
+        latitude=lat, longitude=lon, access_token=access_token, start_date=from_date, end_date=to_date,
+        variables=variables_for_weather_data_call_openmeteo, how_often=TimeUnit.HOURLY
+    )
+
+    if "data" not in weather_data:
+        raise HTTPException(
+            status_code=400,
+            detail="Error, weather data API call failed, no data field in response"
+        )
+
+    calculation_results = calculate_risk_index_probability_wd(
+        parcel=parcel_fc, pest_models=pest_models_db, weather_data=weather_data, lat=lat, lon=lon
     )
 
     return calculation_results

--- a/app/api/api_v1/endpoints/tool.py
+++ b/app/api/api_v1/endpoints/tool.py
@@ -5,11 +5,10 @@ from sqlalchemy.orm import Session
 
 import utils
 from api import deps
-from models import User
 from schemas import list_path_param, DatasetIds
 
 import crud
-
+from utils import fetch_parcel_by_id, fetch_parcel_lat_lon, fetch_weather_data, calculate_gdd_wd
 
 router = APIRouter()
 
@@ -148,3 +147,57 @@ def calculate_gdd(
                                           disease_models=disease_models_db, start=from_date, end=to_date)
 
     return response
+
+@router.get("/calculate-gdd/", dependencies=[Depends(deps.is_using_gatekeeper)])
+def calculate_gdd_fc(
+        parcel_id: str,
+        from_date: datetime.date,
+        to_date: datetime.date,
+        access_token: str = Depends(deps.get_jwt),
+        model_ids: DatasetIds = Depends(list_path_param()),
+        db: Session = Depends(deps.get_db)
+
+):
+    """
+    Calculates and returns GDD values (uses resources located on fc)
+    """
+
+    if from_date > to_date:
+        raise HTTPException(
+            status_code=400,
+            detail="from_date must be later than to_date, from_date: {} | to_date: {}".format(from_date, to_date)
+        )
+
+    parcel_fc = fetch_parcel_by_id(access_token=access_token, parcel_id=parcel_id)
+
+    if not parcel_fc:
+        raise HTTPException(
+            status_code=400,
+            detail="Parcel with ID:{} doesn't exist".format(parcel_id)
+        )
+
+    lat, lon = fetch_parcel_lat_lon(parcel_fc)
+
+    # Now that we have a (lat,lon) pair, we can query the weather service for weather data
+    weather_data = fetch_weather_data(
+        latitude=lat, longitude=lon, access_token=access_token, start_date=datetime.datetime.today().date(), end_date=datetime.datetime.today().date(), variables=["temperature_2m_max"]
+    )
+
+    # Fetch the disease models from the DB
+    disease_models_db = []
+    for disease_id in model_ids.ids:
+        disease_model_db = crud.disease.get(db=db, id=disease_id)
+        if not disease_model_db:
+            raise HTTPException(
+                status_code=400,
+                detail="Error, model with ID {} does not exist".format(disease_id)
+            )
+
+        disease_models_db.append(disease_model_db)
+
+    calculation_results = calculate_gdd_wd(
+        disease_models=disease_models_db,
+        weather_data=weather_data
+    )
+
+    return calculation_results

--- a/app/api/api_v1/endpoints/tool.py
+++ b/app/api/api_v1/endpoints/tool.py
@@ -8,7 +8,6 @@ from api import deps
 from schemas import list_path_param, DatasetIds
 
 import crud
-from utils import fetch_parcel_by_id, fetch_parcel_lat_lon, fetch_weather_data, calculate_gdd_wd
 
 router = APIRouter()
 
@@ -148,56 +147,3 @@ def calculate_gdd(
 
     return response
 
-@router.get("/calculate-gdd/", dependencies=[Depends(deps.is_using_gatekeeper)])
-def calculate_gdd_fc(
-        parcel_id: str,
-        from_date: datetime.date,
-        to_date: datetime.date,
-        access_token: str = Depends(deps.get_jwt),
-        model_ids: DatasetIds = Depends(list_path_param()),
-        db: Session = Depends(deps.get_db)
-
-):
-    """
-    Calculates and returns GDD values (uses resources located on fc)
-    """
-
-    if from_date > to_date:
-        raise HTTPException(
-            status_code=400,
-            detail="from_date must be later than to_date, from_date: {} | to_date: {}".format(from_date, to_date)
-        )
-
-    parcel_fc = fetch_parcel_by_id(access_token=access_token, parcel_id=parcel_id)
-
-    if not parcel_fc:
-        raise HTTPException(
-            status_code=400,
-            detail="Parcel with ID:{} doesn't exist".format(parcel_id)
-        )
-
-    lat, lon = fetch_parcel_lat_lon(parcel_fc)
-
-    # Now that we have a (lat,lon) pair, we can query the weather service for weather data
-    weather_data = fetch_weather_data(
-        latitude=lat, longitude=lon, access_token=access_token, start_date=datetime.datetime.today().date(), end_date=datetime.datetime.today().date(), variables=["temperature_2m_max"]
-    )
-
-    # Fetch the disease models from the DB
-    disease_models_db = []
-    for disease_id in model_ids.ids:
-        disease_model_db = crud.disease.get(db=db, id=disease_id)
-        if not disease_model_db:
-            raise HTTPException(
-                status_code=400,
-                detail="Error, model with ID {} does not exist".format(disease_id)
-            )
-
-        disease_models_db.append(disease_model_db)
-
-    calculation_results = calculate_gdd_wd(
-        disease_models=disease_models_db,
-        weather_data=weather_data
-    )
-
-    return calculation_results

--- a/app/api/deps.py
+++ b/app/api/deps.py
@@ -10,7 +10,6 @@ from crud import user
 
 from core.config import settings
 from db.session import SessionLocal
-from schemas import RefreshToken
 from utils import check_token_for_validity
 
 reusable_oauth2 = OAuth2PasswordBearer(tokenUrl="/api/v1/login/access-token/")
@@ -53,9 +52,9 @@ def get_jwt(
     return token
 
 def get_refresh_token(
-        refresh_token_schema: RefreshToken
-) -> str:
-    if not refresh_token_schema.refresh_token:
+        refresh_token: str = None
+):
+    if not refresh_token:
         raise HTTPException(
             status_code=401,
             detail="Not authenticated"
@@ -63,13 +62,13 @@ def get_refresh_token(
 
     # If you're using the gatekeeper, check whether the token in question is real
     if settings.USING_GATEKEEPER:
-        if not check_token_for_validity(token=refresh_token_schema.refresh_token, token_type="refresh"):
+        if not check_token_for_validity(token=refresh_token, token_type="refresh"):
             raise HTTPException(
                 status_code=400,
                 detail="Error, invalid token"
             )
 
-    return refresh_token_schema.refresh_token
+    return refresh_token
 
 
 # Only use when you're expecting a token that came from PDM, not GK

--- a/app/init/init_gatekeeper.py
+++ b/app/init/init_gatekeeper.py
@@ -5,7 +5,8 @@ from core import settings
 from requests.exceptions import RequestException
 
 
-from api.api_v1.endpoints import operator, pest_model, rule, tool, unit
+from api.api_v1.endpoints import operator, pest_model, rule, tool, unit, model, disease
+
 
 def register_apis_to_gatekeeper():
 
@@ -34,6 +35,8 @@ def register_apis_to_gatekeeper():
     apis_to_register.include_router(rule.router, prefix="/rule")
     apis_to_register.include_router(tool.router, prefix="/tool")
     apis_to_register.include_router(unit.router, prefix="/unit")
+    apis_to_register.include_router(model.router, prefix="/model")
+    apis_to_register.include_router(disease.router, prefix="/disease")
 
     for api in apis_to_register.routes:
         try:
@@ -43,7 +46,7 @@ def register_apis_to_gatekeeper():
                 json={
                     "base_url": "http://{}:{}/".format(settings.SERVICE_NAME, settings.SERVICE_PORT),
                     "service_name": settings.SERVICE_NAME,
-                    "endpoint": "api/v1/" + api.path.strip("/"),
+                    "endpoint": "api/v1/" + api.path.lstrip("/"),
                     "methods": list(api.methods)
                 }
             )

--- a/app/utils/__init__.py
+++ b/app/utils/__init__.py
@@ -4,3 +4,5 @@ from .data import *
 from .gdd import *
 from .gkutils import *
 from .custom_logger import get_logger
+from .fcutils import *
+from .wdutils import *

--- a/app/utils/fcutils.py
+++ b/app/utils/fcutils.py
@@ -1,0 +1,55 @@
+from fastapi import HTTPException
+
+import requests
+from requests import RequestException
+
+from core import settings
+
+from shapely import wkt, errors
+
+def fetch_parcel_by_id(
+        access_token: str,
+        parcel_id: str
+):
+
+    try:
+        response_json = requests.get(
+            url=str(settings.GATEKEEPER_BASE_URL).strip("/") + "/api/proxy/farmcalendar/api/v1/FarmParcels/{}/?format=json".format(parcel_id),
+            headers={"Content-Type": "application/json", "Authorization": "Bearer {}".format(access_token)}
+        )
+    except RequestException:
+        raise HTTPException(
+            status_code=400,
+            detail="Error during proxy call via gk"
+        )
+
+    if response_json.status_code == 404:
+        return None
+
+    return response_json.json()
+
+
+def fetch_parcel_lat_lon(
+        parcel: dict
+):
+
+    # First check if the pair (lat,lon) exists, we can use these if they do
+    if parcel["location"]["lat"] and parcel["location"]["lon"]:
+        return parcel["location"]["lat"], parcel["location"]["lon"]
+
+    # if (lat,lon) is set to (None,None) then calculate the centroid from the WKT object and use that as
+    wkt_polygon = parcel["hasGeometry"]["asWKT"]
+
+    # Parse the POLYGON(...) object
+    try:
+        base_geometry = wkt.loads(wkt_polygon)
+    except errors.ShapelyError as se:
+        raise HTTPException(
+            status_code=400,
+            detail="Error during WKT parsing, provided WKT format has issues: {}".format(se)
+        )
+
+    c_latitude = base_geometry.centroid.x
+    c_longitude = base_geometry.centroid.y
+
+    return c_latitude, c_longitude

--- a/app/utils/gdd.py
+++ b/app/utils/gdd.py
@@ -151,10 +151,6 @@ def calculate_gdd_wd(
 
         for day in weather_data["data"]:
 
-            print("IN FOR")
-            print(day)
-            print(type(day))
-
             date = day["date"]
             avg_daily_temp = int(day["values"]["temperature_2m_max"])
 

--- a/app/utils/risk_index.py
+++ b/app/utils/risk_index.py
@@ -138,8 +138,7 @@ def calculate_risk_index_probability_wd(
 
                 current_rule_applies = True
                 for cond in rule.conditions:
-                    condition_applies = eval(f"{hour["values"][openmeteo_friendly_variables[cond.unit.name]]} {cond.operator.symbol} {cond.value}")
-
+                    condition_applies = eval("{} {} {}".format(hour["values"][openmeteo_friendly_variables[cond.unit.name]], cond.operator.symbol, cond.value))
                     if not condition_applies:
                         current_rule_applies = False
                         break

--- a/app/utils/wdutils.py
+++ b/app/utils/wdutils.py
@@ -60,4 +60,10 @@ def fetch_weather_data(
             detail="Error during weather data api call, original error: {}".format(response.reason)
         )
 
+    if response.status_code == 404:
+        raise HTTPException(
+            status_code=400,
+            detail="Error, GK returning 404, Weather Data API missing."
+        )
+
     return response.json()

--- a/app/utils/wdutils.py
+++ b/app/utils/wdutils.py
@@ -7,6 +7,8 @@ from requests import RequestException
 from core import settings
 from enum import Enum
 
+WEATHER_DATA_API_CALL_URL = str(settings.GATEKEEPER_BASE_URL).strip("/") + "/api/proxy/weather_data"
+
 class TimeUnit(Enum):
     HOURLY = "hourly",
     DAILY = "daily"
@@ -24,13 +26,13 @@ def fetch_weather_data(
 ):
     try:
         response = requests.get(
-            url=str(settings.GATEKEEPER_BASE_URL).strip("/") + "/api/proxy/weather_data/api/v1/history/{}".format(how_often),
+            url=WEATHER_DATA_API_CALL_URL + "/api/v1/history/{}".format(how_often),
             headers={"Content-Type": "application/json", "Authorization": "Bearer {}".format(access_token)},
             json={
                 "lat": latitude,
                 "lon": longitude,
-                "start": start_date,
-                "end": end_date,
+                "start": start_date.isoformat(),
+                "end": end_date.isoformat(),
                 "variables": variables,
                 "radius_km": radius_km
             }

--- a/app/utils/wdutils.py
+++ b/app/utils/wdutils.py
@@ -10,9 +10,20 @@ from enum import Enum
 WEATHER_DATA_API_CALL_URL = str(settings.GATEKEEPER_BASE_URL).strip("/") + "/api/proxy/weather_data"
 
 class TimeUnit(Enum):
-    HOURLY = "hourly",
+    HOURLY = "hourly"
     DAILY = "daily"
 
+openmeteo_friendly_variables = {
+    "atmospheric_temperature": "temperature_2m",
+    "atmospheric_relative_humidity" : "relative_humidity_2m",
+    "precipitation": "precipitation",
+    "atmospheric_pressure": "surface_pressure",
+    "average_wind_speed": "wind_speed_10m",
+    "soil_temperature_10cm": "soil_temperature_0_to_7cm",
+    "soil_temperature_20cm": "soil_temperature_7_to_28cm",
+    "soil_temperature_30cm": "soil_temperature_28_to_100cm",
+    "soil_temperature_40cm": "soil_temperature_100_to_255cm"
+}
 
 def fetch_weather_data(
         latitude: float,
@@ -23,10 +34,10 @@ def fetch_weather_data(
         access_token: str,
         radius_km: int = 10,
         how_often: TimeUnit = TimeUnit.DAILY
-):
+) -> dict:
     try:
-        response = requests.get(
-            url=WEATHER_DATA_API_CALL_URL + "/api/v1/history/{}".format(how_often),
+        response = requests.post(
+            url=WEATHER_DATA_API_CALL_URL + "/api/v1/history/{}/".format(how_often.value),
             headers={"Content-Type": "application/json", "Authorization": "Bearer {}".format(access_token)},
             json={
                 "lat": latitude,

--- a/app/utils/wdutils.py
+++ b/app/utils/wdutils.py
@@ -1,0 +1,50 @@
+import datetime
+
+import requests
+from fastapi import HTTPException
+from requests import RequestException
+
+from core import settings
+from enum import Enum
+
+class TimeUnit(Enum):
+    HOURLY = "hourly",
+    DAILY = "daily"
+
+
+def fetch_weather_data(
+        latitude: float,
+        longitude: float,
+        start_date: datetime.date,
+        end_date: datetime.date,
+        variables: list,
+        access_token: str,
+        radius_km: int = 10,
+        how_often: TimeUnit = TimeUnit.DAILY
+):
+    try:
+        response = requests.get(
+            url=str(settings.GATEKEEPER_BASE_URL).strip("/") + "/api/proxy/weather_data/api/v1/history/{}".format(how_often),
+            headers={"Content-Type": "application/json", "Authorization": "Bearer {}".format(access_token)},
+            json={
+                "lat": latitude,
+                "lon": longitude,
+                "start": start_date,
+                "end": end_date,
+                "variables": variables,
+                "radius_km": radius_km
+            }
+        )
+    except RequestException:
+        raise HTTPException(
+            status_code=400,
+            detail="Error during proxy call via gk"
+        )
+
+    if response.status_code == 400:
+        raise HTTPException(
+            status_code=400,
+            detail="Error during weather data api call, original error: {}".format(response.reason)
+        )
+
+    return response.json()


### PR DESCRIPTION
This PR introduces the following API:

GET /api/v1/model/{model_id}/gdd/

It returns the same response as the "offline" version that's located in the /tool/ path, but uses resources obtained from the Farm Calendar and Weather Data services.

Testing:
It successfully responds with the calculated response only when using dummy data.
- The Farm Calendar proxy calls go through, and return parcel information
- The Weather Data service calls aren't registered on the gatekeeper
- Testing with Weather Data service done using direct local instance, seemingly works, though it did return a 405 a couple of times, unknown reason, same calls made to the service

Several bugfixes, including:
- Switched to lstrip instead of strip in gk api registration init function
- Removed separate create_access_token and create_refresh_token functions and merged them into a single create_token function that takes in a parameter for the length until expiration

This is a WIP since there still needs to be a risk index API that uses the same resources from the services