### PR TITLE
Adding date check for GDD FC API

### DIFF
--- a/app/api/api_v1/endpoints/model.py
+++ b/app/api/api_v1/endpoints/model.py
@@ -36,6 +36,12 @@ def calculate_gdd_fc(
             detail="from_date must be later than to_date, from_date: {} | to_date: {}".format(from_date, to_date)
         )
 
+    if to_date >= datetime.date.today():
+        raise HTTPException(
+            status_code=400,
+            detail="to_date must be earlier than today's date, to_date:{}".format(to_date)
+        )
+
     parcel_fc = fetch_parcel_by_id(access_token=access_token, parcel_id=parcel_id)
 
     if not parcel_fc:

--- a/app/utils/gdd.py
+++ b/app/utils/gdd.py
@@ -152,6 +152,9 @@ def calculate_gdd_wd(
         for day in weather_data["data"]:
 
             date = day["date"]
+            if not day["values"]["temperature_2m_max"]:
+                break
+
             avg_daily_temp = int(day["values"]["temperature_2m_max"])
 
             gdd_to_add = 0


### PR DESCRIPTION
Open-meteo returns malformed response for dates dating today and later, added date checks so that no null values pass.